### PR TITLE
Restore board state on url hash change

### DIFF
--- a/src/board/serializer.ts
+++ b/src/board/serializer.ts
@@ -8,7 +8,7 @@ export interface IBoardSerializer {
   onBoardStateChanged():void;
   onUIStateChanged():void;
   save():void;
-  restore(callback:(restored:boolean) => void):void;
+  restore(callback?:(restored:boolean) => void):void;
 }
 
 export class URLBoardSerializer implements IBoardSerializer {
@@ -66,7 +66,7 @@ export class URLBoardSerializer implements IBoardSerializer {
     }
   }
 
-  public restore(callback:(restored:boolean) => void):void {
+  public restore(callback:(restored:boolean) => void = () => {}):void {
     // if there is no hash, there's nothing to restore
     const hash = window.location.hash.substr(1);
     if (hash.length == 0) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -22,6 +22,10 @@ const resizeApp = () => {
 resizeApp();
 window.addEventListener('resize', resizeApp);
 
+window.addEventListener("hashchange", () => {
+  sim.board.serializer.restore();
+});
+
 // load sprites
 const loader = PIXI.loader;
 loader.add('images/parts.json').load(() => {


### PR DESCRIPTION
If the app is active in one tab and you click on a link (or bookmark) to another URL (= different state) the new board state will currently not be loaded automatically, because the state sits in the part of the URL after the '#'. A page reload is necessary.
This change simply triggers a restore of the board if the hash has been changed from outside.